### PR TITLE
Add single-file sample for multiple runtimes

### DIFF
--- a/msbuild-integration-demos/netcore3-single-file/README.md
+++ b/msbuild-integration-demos/netcore3-single-file/README.md
@@ -6,10 +6,12 @@ The feature provides a native way for dependencies embedding which is most benef
 # Running the example
 This directory contains an example of integrating SmartAssembly into .NET Core 3 single-file executable build:
 - [simplified-example](simplified-example) - .NET Core 3.1 console application protected by SmartAssembly, published as single-file.
+- [multiple-runtimes](multiple-runtimes) - .NET Core 3.1 WPF application protected by SmartAssembly, published as single-file for **win-x64** and **win-x86** runtimes separately.
 
 Execute the `publish-and-run.bat` file from example above, to build, publish, and run the application protected by SmartAssembly.
 
 # More information
 Follow our documentation to see how to protect your single-file application by integrating SmartAssembly into your build process.
 
-https://documentation.red-gate.com/sa7/building-your-assembly/using-smartassembly-with-single-file-executables-net-core-3
+- https://documentation.red-gate.com/sa8/building-your-assembly/using-smartassembly-with-single-file-executables-net-core-3
+- https://documentation.red-gate.com/sa8/building-your-assembly/using-smartassembly-with-single-file-executables-net-core-3/obfuscating-multiple-runtimes

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp.sln
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30523.141
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "SampleApp\SampleApp.csproj", "{80E2B0A1-4A6B-49F6-99DA-70502DB030A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{80E2B0A1-4A6B-49F6-99DA-70502DB030A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80E2B0A1-4A6B-49F6-99DA-70502DB030A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80E2B0A1-4A6B-49F6-99DA-70502DB030A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80E2B0A1-4A6B-49F6-99DA-70502DB030A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AB00FDA8-DBC8-4B7E-8B12-3E06E0E7CC50}
+	EndGlobalSection
+EndGlobal

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/App.xaml
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="SampleApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:SampleApp"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/App.xaml.cs
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace SampleApp
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/AssemblyInfo.cs
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/MainWindow.xaml
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/MainWindow.xaml
@@ -1,0 +1,22 @@
+﻿<Window x:Class="SampleApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SampleApp"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <StackPanel Margin="20">
+        <TextBlock>
+            <Run Text="SecretClass type name: " FontWeight="Bold" />
+            <Run Text="{Binding Path=ObfuscatedTypeName, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
+                 FontSize="30" Background="Azure" />
+            <Run Text="(should be obfuscated)"/>
+        </TextBlock>
+        <TextBlock>
+            <Run Text="Assembly bitness: " FontWeight="Bold"/>
+            <Run Text="{Binding Path=AssemblyBitness, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
+                 FontSize="30" Background="Azure" />
+        </TextBlock>
+    </StackPanel>
+</Window>

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/MainWindow.xaml.cs
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/MainWindow.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Reflection;
+using System.Windows;
+
+namespace SampleApp
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        // You may want to move this to a separate ViewModel
+        public string ObfuscatedTypeName => typeof(SecretClass).FullName;
+        public string AssemblyBitness => typeof(MainWindow).Assembly.GetName().ProcessorArchitecture switch
+        {
+            ProcessorArchitecture.None => "Unknown",
+            ProcessorArchitecture.MSIL => "AnyCPU",
+            ProcessorArchitecture.X86 => "32-bit",
+            ProcessorArchitecture.IA64 => "IA-64",
+            ProcessorArchitecture.Amd64 => "64-bit",
+            ProcessorArchitecture.Arm => "ARM",
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/SampleApp.csproj
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/SampleApp.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <Target Name="SetAssemblyPathsForSA" BeforeTargets="BuildWithSmartAssembly">
+    <PropertyGroup>
+      <SmartAssemblyInput>$(TargetPath)</SmartAssemblyInput>
+      <SmartAssemblyOutput>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</SmartAssemblyOutput>
+    </PropertyGroup>
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="RedGate.SmartAssembly.MSBuild" Version="*-*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/SampleApp.saproj
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/SampleApp.saproj
@@ -1,0 +1,34 @@
+<SmartAssemblyProject ProjectId="{69c1f16e-fcbd-46dd-8c23-436eae0d1687}" Version="2.0">
+    <MainAssemblyFileName>.\bin\Release\netcoreapp3.1\win-x64\SampleApp.dll</MainAssemblyFileName>
+    <Configuration Name="Release">
+        <Options>
+            <ExceptionReporting Template="res:{SmartExceptions}.NoUI.dll" />
+            <FeatureUsageReporting Template="res:SmartUsageWithoutUI.dll" />
+            <StringsEncoding />
+            <StrongNameSigning Sign="0" />
+            <Obfuscation ChangeMethodParent="1" CompilerGeneratedSerializable="0" FieldsNameMangling="3" NameMangling="1" />
+            <OtherProtections />
+            <OtherOptimizations />
+            <Debugging />
+            <CopyDependencies />
+        </Options>
+        <ApplicationName />
+        <Assemblies>
+            <Assembly AssemblyName="SampleApp, Culture=neutral, PublicKeyToken=null">
+                <Merging>
+                    <ResourcesCompression />
+                    <MemberRefsProxy />
+                    <Pruning>
+                        <Exclusion />
+                    </Pruning>
+                    <Obfuscation Obfuscate="1">
+                        <Exclusion />
+                    </Obfuscation>
+                    <ControlFlow />
+                </Merging>
+                <Embedding />
+            </Assembly>
+        </Assemblies>
+        <Destination DestinationFileName=".\bin\Release\netcoreapp3.1\win-x64\sa\SampleApp.dll" />
+    </Configuration>
+</SmartAssemblyProject>

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/SecretClass.cs
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/SampleApp/SecretClass.cs
@@ -1,0 +1,7 @@
+﻿namespace SampleApp
+{
+    class SecretClass
+    {
+        // should be obfuscated
+    }
+}

--- a/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/build.bat
+++ b/msbuild-integration-demos/netcore3-single-file/multiple-runtimes/build.bat
@@ -1,0 +1,8 @@
+dotnet publish .\SampleApp\SampleApp.csproj -r win-x64 -p:PublishSingleFile=true -c Release
+dotnet publish .\SampleApp\SampleApp.csproj -r win-x86 -p:PublishSingleFile=true -c Release
+
+REM Execute 64-bit assembly
+.\SampleApp\bin\Release\netcoreapp3.1\win-x64\publish\SampleApp.exe
+
+REM Execute 32-bit assembly
+.\SampleApp\bin\Release\netcoreapp3.1\win-x86\publish\SampleApp.exe


### PR DESCRIPTION
This is a sample of a .NET Core 3.1 WPF application, targeting multiple runtimes (win-x64 and win-x86), obfuscated using a single SmartAssembly project file.

It follows the documentation at: https://documentation.red-gate.com/sa8/building-your-assembly/using-smartassembly-with-single-file-executables-net-core-3/obfuscating-multiple-runtimes