### PR TITLE
Change framework to. Net8.0-windows and latest  SmartExceptionCore package added.

### DIFF
--- a/ErrorReporting/CSharp/ConsoleAppWithErrorReporting/ConsoleAppWithErrorReporting.csproj
+++ b/ErrorReporting/CSharp/ConsoleAppWithErrorReporting/ConsoleAppWithErrorReporting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/ErrorReporting/CSharp/NuGet.Config
+++ b/ErrorReporting/CSharp/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Localfeed" value="C:\Users\varad_gad\Downloads" />
+  </packageSources>
+</configuration>

--- a/ErrorReporting/CSharp/Sample 01 - Without User Interface (.NET Standard)/Sample 01 - Without User Interface (.NET Standard).csproj
+++ b/ErrorReporting/CSharp/Sample 01 - Without User Interface (.NET Standard)/Sample 01 - Without User Interface (.NET Standard).csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore">
-      <Version>*-*</Version>
-    </PackageReference>
+    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore" Version="8.3.4.6312" />
   </ItemGroup>
 
 </Project>

--- a/ErrorReporting/CSharp/Sample 01 - Without User Interface/Sample 01 - Without User Interface.csproj
+++ b/ErrorReporting/CSharp/Sample 01 - Without User Interface/Sample 01 - Without User Interface.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net4.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore">
-      <Version>*-*</Version>
-    </PackageReference>
+    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore" Version="8.3.4.6312" />
   </ItemGroup>
 
 </Project>

--- a/ErrorReporting/CSharp/Sample 02 - Standard Template/Sample 02 - Standard Template.csproj
+++ b/ErrorReporting/CSharp/Sample 02 - Standard Template/Sample 02 - Standard Template.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net4.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
 
@@ -17,9 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore">
-      <Version>*-*</Version>
-    </PackageReference>
+    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore" Version="8.3.4.6312" />
   </ItemGroup>
 
 </Project>

--- a/ErrorReporting/CSharp/Sample 03 - Template With Custom UI/Sample 03 - Template With Custom UI.csproj
+++ b/ErrorReporting/CSharp/Sample 03 - Template With Custom UI/Sample 03 - Template With Custom UI.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net4.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore">
-      <Version>*-*</Version>
-    </PackageReference>
+    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore" Version="8.3.4.6312" />
   </ItemGroup>
 
 </Project>

--- a/ErrorReporting/CSharp/Sample 04 - Send Report via Email/Sample 04 - Send Report via Email.csproj
+++ b/ErrorReporting/CSharp/Sample 04 - Send Report via Email/Sample 04 - Send Report via Email.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net4.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
 
@@ -17,9 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore">
-      <Version>*-*</Version>
-    </PackageReference>
+    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore" Version="8.3.4.6312" />
   </ItemGroup>
 
 </Project>

--- a/ErrorReporting/CSharp/Sample 05 - Send through Secured Proxy/Sample 05 - Send through Secured Proxy.csproj
+++ b/ErrorReporting/CSharp/Sample 05 - Send through Secured Proxy/Sample 05 - Send through Secured Proxy.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net4.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore">
-      <Version>*-*</Version>
-    </PackageReference>
+    <PackageReference Include="RedGate.SmartAssembly.SmartExceptionsCore" Version="8.3.4.6312" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What changes are delivered as part of this PR?
We have updated the framework to .Net8.0-windows and added the latest the SmartExceptionCore package.

## Why are you making this change?
We made these changes to ensure that the templates support both WinForms and WPF applications.

## Impact
Which components are being affected by this change?
ErrorReporting templates.

## PR contributors
@varadgad 

## Release Notes and User Documentation site
 - [ ] Is `SA_RELEASENOTES` and User Documentation site updated?
   - NA


## Version update 
 - [Yes] Minor version update (if yes, provide reason)
   - NA
 - [ ] Major Version update (if yes, provide reason)
    - NA
